### PR TITLE
Use activity-scoped MainViewModel in NavGraph

### DIFF
--- a/app/src/main/java/com/lurenjia534/skydrivex/MainActivity.kt
+++ b/app/src/main/java/com/lurenjia534/skydrivex/MainActivity.kt
@@ -48,7 +48,8 @@ fun SkyDriveXAppContent(viewModel: MainViewModel = hiltViewModel()) {
                 .padding(innerPadding)) {
                 NavGraph(
                     navController = navController,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(),
+                    viewModel = viewModel
                 )
             }
         }

--- a/app/src/main/java/com/lurenjia534/skydrivex/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/lurenjia534/skydrivex/ui/navigation/NavGraph.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -18,7 +17,8 @@ import com.lurenjia534.skydrivex.viewmodel.MainViewModel
 @Composable
 fun NavGraph(
     navController: NavHostController,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel
 ) {
     NavHost(
         navController = navController,
@@ -32,7 +32,6 @@ fun NavGraph(
             FilesScreen()
         }
         composable(NavDestination.Profile.route) {
-            val viewModel: MainViewModel = hiltViewModel()
             val uiState by viewModel.userState.collectAsState()
             ProfileScreen(uiState = uiState, onRefresh = viewModel::retry)
         }

--- a/app/src/main/java/com/lurenjia534/skydrivex/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/lurenjia534/skydrivex/viewmodel/MainViewModel.kt
@@ -51,10 +51,18 @@ class MainViewModel @Inject constructor(
         authManager.getCurrentAccount(object : ISingleAccountPublicClientApplication.CurrentAccountCallback {
             override fun onAccountLoaded(activeAccount: IAccount?) {
                 _account.value = activeAccount
+                if (activeAccount != null) {
+                    acquireTokenSilent()
+                }
             }
 
             override fun onAccountChanged(priorAccount: IAccount?, currentAccount: IAccount?) {
                 _account.value = currentAccount
+                if (currentAccount != null) {
+                    acquireTokenSilent()
+                } else {
+                    _userState.value = UserUiState(data = null, isLoading = false, error = null)
+                }
             }
 
             override fun onError(exception: MsalException) {


### PR DESCRIPTION
## Summary
- Pass MainViewModel into NavGraph instead of creating a new scoped instance
- Provide activity-level MainViewModel from SkyDriveXAppContent to NavGraph
- Automatically reload user info whenever the signed-in account changes

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `ANDROID_HOME=/usr/lib/android-sdk ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c5fadb8c832fba2e81b5957491a4